### PR TITLE
fix: make release workflow idempotent for tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,16 +106,23 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          # Commit version bump
-          git add pyproject.toml
-          git commit -m "chore: bump version to ${{ steps.version.outputs.VERSION_NUMBER }}"
+          # Check if tag already exists
+          if git rev-parse "${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.VERSION }} already exists, skipping tag creation"
+            # Checkout to the existing tag to ensure we build the right version
+            git checkout "${{ steps.version.outputs.VERSION }}"
+          else
+            # Commit version bump
+            git add pyproject.toml
+            git commit -m "chore: bump version to ${{ steps.version.outputs.VERSION_NUMBER }}"
 
-          # Create annotated tag
-          git tag -a "${{ steps.version.outputs.VERSION }}" -m "Release ${{ steps.version.outputs.VERSION }}"
+            # Create annotated tag
+            git tag -a "${{ steps.version.outputs.VERSION }}" -m "Release ${{ steps.version.outputs.VERSION }}"
 
-          # Push commit and tag
-          git push origin HEAD:main
-          git push origin "${{ steps.version.outputs.VERSION }}"
+            # Push commit and tag
+            git push origin HEAD:main
+            git push origin "${{ steps.version.outputs.VERSION }}"
+          fi
 
       - name: 📦 Build distribution
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,15 +102,15 @@ jobs:
           grep "^version" pyproject.toml
 
       - name: 🏷️ Commit version bump and create tag
+        id: create_tag
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
           # Check if tag already exists
           if git rev-parse "${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.version.outputs.VERSION }} already exists, skipping tag creation"
-            # Checkout to the existing tag to ensure we build the right version
-            git checkout "${{ steps.version.outputs.VERSION }}"
+            echo "Tag ${{ steps.version.outputs.VERSION }} already exists, skipping release"
+            echo "tag_created=false" >> $GITHUB_OUTPUT
           else
             # Commit version bump
             git add pyproject.toml
@@ -122,13 +122,17 @@ jobs:
             # Push commit and tag
             git push origin HEAD:main
             git push origin "${{ steps.version.outputs.VERSION }}"
+
+            echo "tag_created=true" >> $GITHUB_OUTPUT
           fi
 
       - name: 📦 Build distribution
+        if: steps.create_tag.outputs.tag_created == 'true'
         run: |
           python -m build --wheel --sdist
 
       - name: 📋 Generate release notes from PR
+        if: steps.create_tag.outputs.tag_created == 'true'
         id: release_notes
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -162,6 +166,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: 🚀 Create GitHub Release
+        if: steps.create_tag.outputs.tag_created == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
@@ -184,6 +189,7 @@ jobs:
           generate_release_notes: true
 
       - name: 🚀 Publish to PyPI
+        if: steps.create_tag.outputs.tag_created == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-02-01
+
 ### Added
 - Python 3.13 and 3.14 support
 - Dev release workflow for automatic TestPyPI publishing on dev branch pushes
 - Codecov configuration with flags for unit tests and integration tests
 - JUnit XML test output for CI reporting
 - Concurrency control in CI workflows to cancel redundant runs
-- CI status aggregation job (`ci-expected`) for reliable status checks
+- CI status aggregation job for reliable status checks
+- Security scanning with Bandit
 
 ### Changed
 - **Breaking**: Migrated from Poetry to uv for dependency management
+- **Breaking**: Migrated to src/ layout for better package isolation
 - **Breaking**: Upgraded to LangChain v1.x ecosystem:
   - `langchain-core` ^0.3.15 → ^1.0.0
   - `langchain` ^0.3.14 → ^1.0.0
@@ -30,21 +34,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `actions/setup-python` v5 → v6
   - `astral-sh/setup-uv` → v7
   - `pypa/gh-action-pypi-publish` → v1.13.0
+  - `codecov/codecov-action` → v5
 - Standardized import path for `create_vector_store` to use `fmp_data.lc`
 - Updated docstring examples in toolkits.py to use modern `create_react_agent` pattern
 - Changed release workflow to use PR labels (`release:major`, `release:minor`, `release:patch`)
 - Release workflow now uses trusted publishing (OIDC) for PyPI
+- Made release workflow idempotent (handles existing tags gracefully)
 - Default Python version set to 3.12
 - Ruff target version updated to py312
 - Updated all dev/test dependency versions to latest
+- Migrated from deprecated `codecov/test-results-action` to `codecov/codecov-action` with `report_type`
 
 ### Removed
 - Poetry lock file (replaced by uv.lock)
 - `langchain-community` dependency (not directly used)
 - Legacy release workflow with `poetry version` commands
+- scripts/ directory (unused utility scripts)
 
 ### Fixed
 - Import sorting in tools.py after standardizing fmp_data imports
+- Mypy type errors for CI compatibility
+- Codecov flag paths to match src/ layout
+- README and CI paths updated for src/ layout
 
 ## [0.1.1] - 2024-01-20
 
@@ -87,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vector store for intelligent tool selection
 - Basic documentation and examples
 
-[Unreleased]: https://github.com/MehdiZare/langchain-fmp-data/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/MehdiZare/langchain-fmp-data/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/MehdiZare/langchain-fmp-data/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/MehdiZare/langchain-fmp-data/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/MehdiZare/langchain-fmp-data/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ uv run mypy src/langchain_fmp_data/
 
 ### GitHub Actions Workflows
 
-- **CI**: Runs on all PRs and pushes to main/dev branches
+- **CI**: Runs on all PRs
   - Linting with Ruff
   - Type checking with Mypy
+  - Security scanning with Bandit
   - Tests on Python 3.10, 3.11, 3.12, 3.13, 3.14
-  - Cross-platform testing (Ubuntu, macOS, Windows)
   - Code coverage reporting to Codecov
 
 - **Release**: Automated version management and publishing
@@ -216,15 +216,15 @@ Follow conventional commits format:
 
 ```
 langchain-fmp-data/
-├── langchain_fmp_data/     # Main package code
-│   ├── __init__.py         # Package exports
-│   ├── agent.py            # LangGraph agent implementation
-│   ├── tools.py            # FMPDataTool implementation
-│   └── toolkits.py         # FMPDataToolkit implementation
+├── src/
+│   └── langchain_fmp_data/ # Main package code
+│       ├── __init__.py     # Package exports
+│       ├── agent.py        # LangGraph agent implementation
+│       ├── tools.py        # FMPDataTool implementation
+│       └── toolkits.py     # FMPDataToolkit implementation
 ├── tests/                  # Test suite
 │   ├── unit_tests/         # Unit tests
 │   └── integration_tests/  # Integration tests
-├── scripts/                # Utility scripts
 ├── .github/                # GitHub Actions workflows
 ├── pyproject.toml          # Project configuration
 ├── README.md               # This file


### PR DESCRIPTION
Skip tag creation if tag already exists to prevent duplicate workflow runs from failing.